### PR TITLE
Added `CriticalSection` API to the `sync` package.

### DIFF
--- a/arm/cortexm/platform/st/stm32h7x7/cm7/hal/uart/uart_stm32h7x7.go
+++ b/arm/cortexm/platform/st/stm32h7x7/cm7/hal/uart/uart_stm32h7x7.go
@@ -1,3 +1,5 @@
+//go:build stm32h7x7
+
 package uart
 
 import (

--- a/arm/cortexm/runtime/entry.go
+++ b/arm/cortexm/runtime/entry.go
@@ -85,5 +85,5 @@ func _entry() {
 	EnableInterrupts(state)
 
 	// Schedule goroutines.
-	triggerPendSV()
+	gosched()
 }

--- a/arm/cortexm/runtime/goroutine.S
+++ b/arm/cortexm/runtime/goroutine.S
@@ -4,14 +4,14 @@
 .type PendSvHandler, %function
 PendSvHandler:
     push {lr}                           // Temporarily store LR on the stack since the branch below will NOT restore LR.
-    bl runtime.runScheduler             // Choose the next goroutine
+    bl runtime.schedule             // Choose the next goroutine
 #ifdef __thumb2__
     pop {lr}                            // Restore the previous value of LR
 #else
     pop {r1}
     mov lr, r1
 #endif
-    cmp r0, #0                          // Check if runScheduler returned false
+    cmp r0, #0                          // Check if runtime.schedule returned false
     beq _restore_and_return             // No context switch should be performed
 
     ldr r0, =runtime.currentGoroutine   // Load the address of the current goroutine pointer into R0

--- a/arm/cortexm/runtime/goroutine.go
+++ b/arm/cortexm/runtime/goroutine.go
@@ -90,6 +90,6 @@ func startGoroutine(g *_goroutine) {
 	// Busy loop until another task can be run.
 	for {
 		// Trigger a context switch.
-		triggerPendSV()
+		gosched()
 	}
 }

--- a/arm/cortexm/runtime/timing.go
+++ b/arm/cortexm/runtime/timing.go
@@ -65,11 +65,11 @@ func sysTickHandler() {
 	}
 
 	// Trigger a PendSV interrupt to run the scheduler
-	triggerPendSV()
+	gosched()
 }
 
-//go:export triggerPendSV runtime.schedulerPause
-func triggerPendSV() {
+//go:export gosched runtime.gosched
+func gosched() {
 	// Set the PendSV flag
 	scb.Scb.Icsr.SetPendsvset(true)
 }


### PR DESCRIPTION
runtime:
Renamed `runtime.schedulerPause` to `runtime.gosched`. Renamed `runtime.runScheduler` to `runtime.schedule`.