### PR TITLE
Implements Read/Write APIs of SDIO for STM32H7x7

### DIFF
--- a/arm/cortexm/platform/st/stm32h7x7/cm7/examples/timer/main.go
+++ b/arm/cortexm/platform/st/stm32h7x7/cm7/examples/timer/main.go
@@ -32,8 +32,8 @@ func nanotime() uint64 {
 }
 
 //sigo:export addsleep runtime.addsleep
-func addsleep(deadline uint64) {
-	TIM2.SetAlarm(deadline/timescale, alarm)
+func addsleep(deadline uint64) bool {
+	return !TIM2.SetAlarm(deadline/timescale, alarm)
 }
 
 func init() {

--- a/arm/cortexm/platform/st/stm32h7x7/cm7/hal/clocks.go
+++ b/arm/cortexm/platform/st/stm32h7x7/cm7/hal/clocks.go
@@ -73,7 +73,7 @@ var (
 
 	Divp2FrequencyHz uint64 = 128_000_000
 	Divq2FrequencyHz uint64 = 128_000_000
-	Divr2FrequencyHz uint64 = 150_000_000
+	Divr2FrequencyHz uint64 = 100_000_000
 
 	Divp3FrequencyHz uint64 = 128_000_000
 	Divq3FrequencyHz uint64 = 128_000_000

--- a/arm/cortexm/platform/st/stm32h7x7/cm7/hal/sdio/cmd.go
+++ b/arm/cortexm/platform/st/stm32h7x7/cm7/hal/sdio/cmd.go
@@ -1,0 +1,75 @@
+package sdio
+
+import (
+	coresdio "pkg.si-go.dev/chip/core/hal/sdio"
+)
+
+const (
+	CMD0  = coresdio.CMD0
+	CMD2  = coresdio.CMD2
+	CMD3  = coresdio.CMD3
+	CMD4  = coresdio.CMD4
+	CMD5  = coresdio.CMD5
+	CMD6  = coresdio.CMD6
+	CMD7  = coresdio.CMD7
+	CMD8  = coresdio.CMD8
+	CMD9  = coresdio.CMD9
+	CMD10 = coresdio.CMD10
+	CMD11 = coresdio.CMD11
+	CMD12 = coresdio.CMD12
+	CMD13 = coresdio.CMD13
+	CMD15 = coresdio.CMD15
+	CMD16 = coresdio.CMD16
+	CMD17 = coresdio.CMD17
+	CMD18 = coresdio.CMD18
+	CMD19 = coresdio.CMD19
+	CMD20 = coresdio.CMD20
+	CMD21 = coresdio.CMD21
+	CMD22 = coresdio.CMD22
+	CMD23 = coresdio.CMD23
+	CMD24 = coresdio.CMD24
+	CMD25 = coresdio.CMD25
+	CMD27 = coresdio.CMD27
+	CMD28 = coresdio.CMD28
+	CMD29 = coresdio.CMD29
+	CMD30 = coresdio.CMD30
+	CMD32 = coresdio.CMD32
+	CMD33 = coresdio.CMD33
+	CMD34 = coresdio.CMD34
+	CMD35 = coresdio.CMD35
+	CMD36 = coresdio.CMD36
+	CMD37 = coresdio.CMD37
+	CMD38 = coresdio.CMD38
+	CMD39 = coresdio.CMD39
+	CMD40 = coresdio.CMD40
+	CMD42 = coresdio.CMD42
+	CMD43 = coresdio.CMD43
+	CMD44 = coresdio.CMD44
+	CMD45 = coresdio.CMD45
+	CMD46 = coresdio.CMD46
+	CMD47 = coresdio.CMD47
+	CMD48 = coresdio.CMD48
+	CMD49 = coresdio.CMD49
+	CMD50 = coresdio.CMD50
+	CMD52 = coresdio.CMD52
+	CMD53 = coresdio.CMD53
+	CMD55 = coresdio.CMD55
+	CMD56 = coresdio.CMD56
+	CMD57 = coresdio.CMD57
+	CMD58 = coresdio.CMD58
+	CMD59 = coresdio.CMD59
+
+	ACMD6  = coresdio.ACMD6
+	ACMD13 = coresdio.ACMD13
+	ACMD14 = coresdio.ACMD14
+	ACMD15 = coresdio.ACMD15
+	ACMD16 = coresdio.ACMD16
+	ACMD22 = coresdio.ACMD22
+	ACMD23 = coresdio.ACMD23
+	ACMD28 = coresdio.ACMD28
+	ACMD41 = coresdio.ACMD41
+	ACMD42 = coresdio.ACMD42
+	ACMD51 = coresdio.ACMD51
+	ACMD53 = coresdio.ACMD53
+	ACMD54 = coresdio.ACMD54
+)

--- a/arm/cortexm/platform/st/stm32h7x7/cm7/linker_stm32h747xi.ld
+++ b/arm/cortexm/platform/st/stm32h7x7/cm7/linker_stm32h747xi.ld
@@ -4,7 +4,7 @@ MEMORY
 	FLASH (rwx) : ORIGIN = 0x8000000, LENGTH = 2000K				/* Flash memory */
 	DTCM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K				/* DTCM RAM (instruction) */
 	SRAM_AXI (rwx) : ORIGIN = 0x24000000, LENGTH = 512K				/* SRAM mapped on AXI bus */
-	RAM (rwx) : ORIGIN = 0x30000000, LENGTH = 288K				/* [SRAM1 : SRAM3] */
+	RAM (rwx) : ORIGIN = 0x24000000, LENGTH = 512K				/* [SRAM1 : SRAM3] */
 	SRAM1 (rwx) : ORIGIN = 0x30000000, LENGTH = 128K				/* SRAM1 (D2 domain) */
 	SRAM2 (rwx) : ORIGIN = 0x30020000, LENGTH = 128K				/* SRAM2 (D2 domain) */
 	SRAM3 (rwx) : ORIGIN = 0x30040000, LENGTH = 32K				/* SRAM3 (D2 domain) */

--- a/arm/cortexm/runtime/goroutine.S
+++ b/arm/cortexm/runtime/goroutine.S
@@ -4,7 +4,7 @@
 .type PendSvHandler, %function
 PendSvHandler:
     push {lr}                           // Temporarily store LR on the stack since the branch below will NOT restore LR.
-    bl runtime.schedule             // Choose the next goroutine
+    bl runtime.schedule                 // Choose the next goroutine
 #ifdef __thumb2__
     pop {lr}                            // Restore the previous value of LR
 #else

--- a/arm/cortexm/runtime/goroutine.go
+++ b/arm/cortexm/runtime/goroutine.go
@@ -41,6 +41,7 @@ type basicGoroutineContext struct {
 	R11 uintptr
 	LR  uintptr
 }
+
 type goroutineContext struct {
 	basicGoroutineContext
 	extendedGoroutineContext

--- a/core/hal/errors.go
+++ b/core/hal/errors.go
@@ -1,10 +1,11 @@
 package hal
 
 const (
-	ErrInvalidPinout Error = -1
-	ErrInvalidConfig Error = -2
-	ErrInvalidBuffer Error = -3
-	ErrInvalidState  Error = -4
+	ErrInvalidPinout    Error = -1
+	ErrInvalidConfig    Error = -2
+	ErrInvalidBuffer    Error = -3
+	ErrInvalidState     Error = -4
+	ErrInvalidParameter Error = -5
 )
 
 type Error int
@@ -21,6 +22,8 @@ func (e Error) Error() string {
 		return "invalid buffer"
 	case -4:
 		return "invalid state"
+	case -5:
+		return "invalid parameter"
 	default:
 		return "unknown error"
 	}

--- a/core/hal/sdio/cmd.go
+++ b/core/hal/sdio/cmd.go
@@ -1,0 +1,213 @@
+package sdio
+
+type CommandType uint32
+
+const (
+	CmdFlagBasic CommandType = 1 << (8 + iota + 1)
+	CmdFlagCommAndQueue
+	CmdFlagBlockRead
+	CmdFlagBlockWrite
+	CmdFlagErase
+	CmdFlagWriteProtection
+	CmdFlagLockCard
+	CmdFlagApplicationSpecific
+	CmdFlagIOMode
+	CmdFlagSwitch
+	CmdFlagExtension
+)
+
+const (
+	CMD0  CommandType = 0 | CmdFlagBasic
+	CMD2  CommandType = 2 | CmdFlagBasic
+	CMD3  CommandType = 3 | CmdFlagBasic
+	CMD4  CommandType = 4 | CmdFlagBasic
+	CMD5  CommandType = 5 | CmdFlagIOMode
+	CMD6  CommandType = 6 | CmdFlagSwitch
+	CMD7  CommandType = 7 | CmdFlagBasic
+	CMD8  CommandType = 8 | CmdFlagBasic
+	CMD9  CommandType = 9 | CmdFlagBasic
+	CMD10 CommandType = 10 | CmdFlagBasic
+	CMD11 CommandType = 11 | CmdFlagBasic
+	CMD12 CommandType = 12 | CmdFlagBasic
+	CMD13 CommandType = 13 | CmdFlagBasic
+	CMD15 CommandType = 15 | CmdFlagBasic
+	CMD16 CommandType = 16 | CmdFlagLockCard
+	CMD17 CommandType = 17 | CmdFlagBlockRead
+	CMD18 CommandType = 18 | CmdFlagBlockRead
+	CMD19 CommandType = 19 | CmdFlagBlockRead
+	CMD20 CommandType = 20
+	CMD21 CommandType = 21 | CmdFlagExtension
+	CMD22 CommandType = 22
+	CMD23 CommandType = 23 | CmdFlagApplicationSpecific
+	CMD24 CommandType = 24 | CmdFlagBlockWrite
+	CMD25 CommandType = 25 | CmdFlagBlockWrite
+	CMD27 CommandType = 27 | CmdFlagBlockWrite
+	CMD28 CommandType = 28 | CmdFlagWriteProtection
+	CMD29 CommandType = 29 | CmdFlagWriteProtection
+	CMD30 CommandType = 30 | CmdFlagWriteProtection
+	CMD32 CommandType = 32 | CmdFlagErase
+	CMD33 CommandType = 33 | CmdFlagErase
+	CMD34 CommandType = 34 | CmdFlagSwitch
+	CMD35 CommandType = 35 | CmdFlagSwitch
+	CMD36 CommandType = 36 | CmdFlagSwitch
+	CMD37 CommandType = 37 | CmdFlagSwitch
+	CMD38 CommandType = 38 | CmdFlagErase
+	CMD39 CommandType = 39 | CmdFlagExtension
+	CMD40 CommandType = 40 | CmdFlagLockCard
+	CMD42 CommandType = 42 | CmdFlagLockCard
+	CMD43 CommandType = 43 | CmdFlagCommAndQueue
+	CMD44 CommandType = 44 | CmdFlagCommAndQueue
+	CMD45 CommandType = 45 | CmdFlagCommAndQueue
+	CMD46 CommandType = 46 | CmdFlagCommAndQueue
+	CMD47 CommandType = 47 | CmdFlagCommAndQueue
+	CMD48 CommandType = 48 | CmdFlagExtension
+	CMD49 CommandType = 49 | CmdFlagExtension
+	CMD50 CommandType = 50 | CmdFlagSwitch
+	CMD52 CommandType = 52 | CmdFlagIOMode
+	CMD53 CommandType = 53 | CmdFlagIOMode
+	CMD55 CommandType = 55 | CmdFlagApplicationSpecific
+	CMD56 CommandType = 56 | CmdFlagApplicationSpecific
+	CMD57 CommandType = 57 | CmdFlagSwitch
+	CMD58 CommandType = 58 | CmdFlagExtension
+	CMD59 CommandType = 59 | CmdFlagExtension
+
+	ACMD6  CommandType = 6 | CmdFlagApplicationSpecific
+	ACMD13 CommandType = 13 | CmdFlagApplicationSpecific
+	ACMD14 CommandType = 14 | CmdFlagApplicationSpecific
+	ACMD15 CommandType = 15 | CmdFlagApplicationSpecific
+	ACMD16 CommandType = 16 | CmdFlagApplicationSpecific
+	ACMD22 CommandType = 22 | CmdFlagApplicationSpecific
+	ACMD23 CommandType = 23 | CmdFlagApplicationSpecific
+	ACMD28 CommandType = 28 | CmdFlagApplicationSpecific
+	ACMD41 CommandType = 41 | CmdFlagApplicationSpecific
+	ACMD42 CommandType = 42 | CmdFlagApplicationSpecific
+	ACMD51 CommandType = 51 | CmdFlagApplicationSpecific
+	ACMD53 CommandType = 53 | CmdFlagApplicationSpecific
+	ACMD54 CommandType = 54 | CmdFlagApplicationSpecific
+)
+
+func (cmd CommandType) Index() uint32 {
+	return uint32(cmd & 0xFF)
+}
+
+type Direction uint32
+
+const (
+	Read  Direction = 0
+	Write Direction = 1
+)
+
+type OpCode uint32
+
+const (
+	Fixed        OpCode = 0
+	Incrementing OpCode = 1
+)
+
+type BlockMode uint32
+
+const (
+	Bytes  BlockMode = 0
+	Blocks BlockMode = 1
+)
+
+type RAWMode uint32
+
+const (
+	Normal         RAWMode = 0
+	ReadAfterWrite RAWMode = 1
+)
+
+type CMD5Args struct {
+	VoltageBits uint32
+	SwitchTo1v8 uint32
+}
+
+func (cmd CMD5Args) Value() uint32 {
+	var value uint32
+	value |= cmd.VoltageBits & 0xFFFFFF
+	value |= (cmd.SwitchTo1v8 & 0x1) << 24
+	return value
+}
+
+type CMD7Args struct {
+	RCA uint16
+}
+
+func (cmd CMD7Args) Value() uint32 {
+	var value uint32
+	value |= uint32(cmd.RCA) << 16
+	return value
+}
+
+type CMD52Args struct {
+	Data      uint32    // 8 bits (for writes); ignored on reads
+	Address   uint32    // 17 bits
+	Raw       RAWMode   // 0=Normal, 1=ReadAfterWrite (writes only)
+	Function  uint32    // 3 bits (0..7)
+	ReadWrite Direction // 0=Read, 1=Write
+}
+
+const (
+	cmd52DataMask = 0xFF
+	cmd52AddrMask = 0x1FFFF
+	cmd52FuncMask = 0x7
+
+	cmd52DataShift = 0
+	cmd52AddrShift = 9 // leaves bit 8 as required stuff bit (0)
+	cmd52RawShift  = 27
+	cmd52FuncShift = 28
+	cmd52RwShift   = 31
+)
+
+func (cmd CMD52Args) Value() uint32 {
+	// Enforce spec-ish constraints
+	data := cmd.Data & cmd52DataMask
+	addr := cmd.Address & cmd52AddrMask
+	function := cmd.Function & cmd52FuncMask
+
+	// RAW is only meaningful for writes; clear on reads to be safe.
+	raw := uint32(cmd.Raw & 0x1)
+	if cmd.ReadWrite&0x1 == 0 {
+		raw = 0
+	}
+
+	var v uint32
+	v |= data << cmd52DataShift
+	v |= addr << cmd52AddrShift
+	v |= raw << cmd52RawShift
+	v |= function << cmd52FuncShift
+	v |= uint32(cmd.ReadWrite&0x1) << cmd52RwShift
+	return v
+}
+
+type CMD53Args struct {
+	Count     uint32
+	Address   uint32
+	OpCode    OpCode
+	BlockMode BlockMode
+	Function  uint32
+	ReadWrite Direction
+}
+
+func (cmd CMD53Args) Value() uint32 {
+	var value uint32
+	value |= cmd.Count & 0x1FF
+	value |= (cmd.Address & 0x1FFFF) << 9
+	value |= uint32(cmd.OpCode&0x1) << 26
+	value |= uint32(cmd.BlockMode&0x1) << 27
+	value |= (cmd.Function & 0x7) << 28
+	value |= uint32(cmd.ReadWrite&0x1) << 31
+	return value
+}
+
+func DecodeCMD53(args uint32) CMD53Args {
+	return CMD53Args{
+		Count:     args & 0x1FF,
+		Address:   (args >> 9) & 0x1FFFF,
+		OpCode:    OpCode(args>>26) & 0x1,
+		BlockMode: BlockMode(args>>27) & 0x1,
+		Function:  (args >> 28) & 0x7,
+		ReadWrite: Direction(args>>31) & 0x1,
+	}
+}

--- a/core/hal/sdio/response.go
+++ b/core/hal/sdio/response.go
@@ -1,0 +1,54 @@
+package sdio
+
+/* Masks for errors in an R5 response */
+const (
+	R5ComCrcError    = 0x80
+	R5IllegalCommand = 0x40
+	R5IoCurrentState = 0x30
+	R5Error          = 0x08
+	R5FunctionNumber = 0x02
+	R5OutOfRange     = 0x01
+	R5ErrorBits      = R5ComCrcError | R5IllegalCommand | R5Error | R5FunctionNumber | R5OutOfRange
+)
+
+type R4 uint32
+
+func (r R4) Ocr() uint32 {
+	return uint32(r) & 0xFFFFFF
+}
+
+func (r R4) SwitchTo1v8() bool {
+	return (r>>24)&0x1 != 0
+}
+
+func (r R4) MemoryPresent() bool {
+	return (r>>26)&0x1 != 0
+}
+
+func (r R4) NumberOfFunctions() int {
+	return int(r>>27) & 0x7
+}
+
+func (r R4) Ready() bool {
+	return int(r>>31)&0x1 != 0
+}
+
+type R5 uint32
+
+func (r R5) Data() uint8 {
+	return uint8(r)
+}
+
+func (r R5) Flags() uint8 {
+	return uint8(r >> 8)
+}
+
+type R6 uint32
+
+func (r R6) Status() uint16 {
+	return uint16(r)
+}
+
+func (r R6) RCA() uint16 {
+	return uint16(r >> 16)
+}

--- a/core/hal/sdio/sdio.go
+++ b/core/hal/sdio/sdio.go
@@ -21,23 +21,11 @@ const (
 	Hs
 )
 
-type CommandIndex uint8
+type SDType uint8
 
 const (
-	CMD0  CommandIndex = 0
-	CMD2  CommandIndex = 2
-	CMD3  CommandIndex = 3
-	CMD5  CommandIndex = 5
-	CMD7  CommandIndex = 7
-	CMD8  CommandIndex = 8
-	CMD9  CommandIndex = 9
-	CMD12 CommandIndex = 12
-	CMD17 CommandIndex = 17
-	CMD24 CommandIndex = 24
-	CMD41 CommandIndex = 41
-	CMD52 CommandIndex = 52
-	CMD53 CommandIndex = 53
-	CMD55 CommandIndex = 55
+	SDMMC SDType = iota
+	SDIO
 )
 
 type _error uint8
@@ -47,6 +35,7 @@ const (
 	ErrCommandFail
 	ErrCommandCrcFail
 	ErrTimeout
+	ErrDataError
 	ErrNotReady
 )
 
@@ -60,6 +49,8 @@ func (e _error) Error() string {
 		return "command crc fail"
 	case ErrTimeout:
 		return "command timeout"
+	case ErrDataError:
+		return "command data error"
 	case ErrNotReady:
 		return "the card is not ready"
 	default:
@@ -70,20 +61,23 @@ func (e _error) Error() string {
 type Response [4]uint32
 
 type Command struct {
-	Argument uint32
-	Index    CommandIndex
+	Data      []byte
+	BlockSize uint32
+	Argument  uint32
+	Class     CommandType
+}
+
+type Transfer struct {
+	Address    uint32
+	BlockSize  uint16
+	BlockCount uint16
+	Function   uint8
+	Increment  bool
 }
 
 type Host interface {
 	SetBusSpeed(speed BusSpeed) error
 	SetBusWidth(width BusWidth) error
 	SetClockFrequency(hz uint32) error
-
 	SendCommand(cmd Command) (Response, error)
-
-	ReadBlock(buf []byte, blockAddr uint32) error
-	WriteBlock(buf []byte, blockAddr uint32) error
-
-	ReadBlocks(buf []byte, blockAddr, count uint32) error
-	WriteBlocks(buf []byte, blockAddr, count uint32) error
 }


### PR DESCRIPTION
st/stm32h7x7/cm7/hal/sdio:
Implemented ReadBytes, ReadBlocks, WriteBytes and WriteBlocks APIs. Fixed bug in Reconfigure where a deadlock occurred because it called the public method `SetBusSpeed` instead of the private one that does not acquire the mutex.

core/hal/sdio:
Expanded SDIO interface.